### PR TITLE
fix: remove the prebuilt chromium package for linux-6.1-stan-rkr5.1

### DIFF
--- a/pkg.conf.linux-6.1-stan-rkr5.1
+++ b/pkg.conf.linux-6.1-stan-rkr5.1
@@ -56,5 +56,8 @@
       "rk3399pro-bookworm",
       "rk3399pro-bookworm-test"
     ]
+  },
+  "chromium-x11_126.0.6478.126_arm64.deb": {
+    "Releases": []
   }
 }


### PR DESCRIPTION
```
fix: remove the prebuilt chromium package for linux-6.1-stan-rkr5.1
```